### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/shubhuudedon/1d7bd937-cd0f-47e0-8f9d-bda60c25b6a6/6173ac78-da3f-4e23-bcdc-7ce2a56e06c3/_apis/work/boardbadge/8f0c69ae-8949-4484-8f7f-99fb58560872)](https://dev.azure.com/shubhuudedon/1d7bd937-cd0f-47e0-8f9d-bda60c25b6a6/_boards/board/t/6173ac78-da3f-4e23-bcdc-7ce2a56e06c3/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dev.azure.com/shubhuudedon/1d7bd937-cd0f-47e0-8f9d-bda60c25b6a6/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.